### PR TITLE
target/riscv: add vector register vlenb

### DIFF
--- a/target/riscv/cpu.c
+++ b/target/riscv/cpu.c
@@ -347,6 +347,7 @@ static void riscv_cpu_reset(CPUState *cs)
     env->mstatus &= ~(MSTATUS_MIE | MSTATUS_MPRV);
     env->mcause = 0;
     env->pc = env->resetvec;
+    env->vlenb = cpu->cfg.vlen/8;
 #endif
     cs->exception_index = EXCP_NONE;
     env->load_res = -1;

--- a/target/riscv/cpu.h
+++ b/target/riscv/cpu.h
@@ -115,6 +115,7 @@ struct CPURISCVState {
     target_ulong vxrm;
     target_ulong vxsat;
     target_ulong vl;
+    target_ulong vlenb;
     target_ulong vstart;
     target_ulong vtype;
 

--- a/target/riscv/cpu_bits.h
+++ b/target/riscv/cpu_bits.h
@@ -62,6 +62,7 @@
 #define CSR_VXRM            0x00a
 #define CSR_VL              0xc20
 #define CSR_VTYPE           0xc21
+#define CSR_VLENB           0xc22
 
 /* User Timers and Counters */
 #define CSR_CYCLE           0xc00

--- a/target/riscv/csr.c
+++ b/target/riscv/csr.c
@@ -258,6 +258,12 @@ static int write_vstart(CPURISCVState *env, int csrno, target_ulong val)
     return 0;
 }
 
+static int read_vlenb(CPURISCVState *env, int csrno, target_ulong *val)
+{
+    *val = env->vlenb;
+    return 0;
+}
+
 /* User Timers and Counters */
 static int read_instret(CPURISCVState *env, int csrno, target_ulong *val)
 {
@@ -1343,6 +1349,7 @@ static riscv_csr_operations csr_ops[CSR_TABLE_SIZE] = {
     [CSR_VXRM] =                { vs,   read_vxrm,        write_vxrm        },
     [CSR_VL] =                  { vs,   read_vl                             },
     [CSR_VTYPE] =               { vs,   read_vtype                          },
+    [CSR_VLENB] =               { vs,   read_vlenb                          },
     /* User Timers and Counters */
     [CSR_CYCLE] =               { ctr,  read_instret                        },
     [CSR_INSTRET] =             { ctr,  read_instret                        },


### PR DESCRIPTION
The vlenb register is added in this patch. It is the vector register length
in bytes.

Signed-off-by: Greentime Hu <greentime.hu@sifive.com>