### PR TITLE
Support vector registers.

### DIFF
--- a/configure
+++ b/configure
@@ -7879,7 +7879,7 @@ case "$target_name" in
     TARGET_BASE_ARCH=riscv
     TARGET_ABI_DIR=riscv
     mttcg=yes
-    gdb_xml_files="riscv-64bit-cpu.xml riscv-32bit-fpu.xml riscv-64bit-fpu.xml riscv-64bit-csr.xml riscv-64bit-virtual.xml"
+    gdb_xml_files="riscv-64bit-cpu.xml riscv-32bit-fpu.xml riscv-64bit-fpu.xml riscv-64bit-vector-128b.xml riscv-64bit-vector-256b.xml riscv-64bit-vector-512b.xml riscv-64bit-csr.xml riscv-64bit-virtual.xml"
   ;;
   sh4|sh4eb)
     TARGET_ARCH=sh4

--- a/gdb-xml/riscv-32bit-csr.xml
+++ b/gdb-xml/riscv-32bit-csr.xml
@@ -110,6 +110,8 @@
   <reg name="mcause" bitsize="32"/>
   <reg name="mtval" bitsize="32"/>
   <reg name="mip" bitsize="32"/>
+  <reg name="mtinst" bitsize="32"/>
+  <reg name="mtval2" bitsize="32"/>
   <reg name="pmpcfg0" bitsize="32"/>
   <reg name="pmpcfg1" bitsize="32"/>
   <reg name="pmpcfg2" bitsize="32"/>
@@ -232,12 +234,11 @@
   <reg name="hedeleg" bitsize="32"/>
   <reg name="hideleg" bitsize="32"/>
   <reg name="hie" bitsize="32"/>
-  <reg name="htvec" bitsize="32"/>
-  <reg name="hscratch" bitsize="32"/>
-  <reg name="hepc" bitsize="32"/>
-  <reg name="hcause" bitsize="32"/>
-  <reg name="hbadaddr" bitsize="32"/>
+  <reg name="hcounteren" bitsize="32"/>
+  <reg name="htval" bitsize="32"/>
   <reg name="hip" bitsize="32"/>
+  <reg name="htinst" bitsize="32"/>
+  <reg name="hgatp" bitsize="32"/>
   <reg name="mbase" bitsize="32"/>
   <reg name="mbound" bitsize="32"/>
   <reg name="mibase" bitsize="32"/>

--- a/gdb-xml/riscv-64bit-csr.xml
+++ b/gdb-xml/riscv-64bit-csr.xml
@@ -110,6 +110,8 @@
   <reg name="mcause" bitsize="64"/>
   <reg name="mtval" bitsize="64"/>
   <reg name="mip" bitsize="64"/>
+  <reg name="mtinst" bitsize="64"/>
+  <reg name="mtval2" bitsize="64"/>
   <reg name="pmpcfg0" bitsize="64"/>
   <reg name="pmpcfg1" bitsize="64"/>
   <reg name="pmpcfg2" bitsize="64"/>
@@ -232,12 +234,11 @@
   <reg name="hedeleg" bitsize="64"/>
   <reg name="hideleg" bitsize="64"/>
   <reg name="hie" bitsize="64"/>
-  <reg name="htvec" bitsize="64"/>
-  <reg name="hscratch" bitsize="64"/>
-  <reg name="hepc" bitsize="64"/>
-  <reg name="hcause" bitsize="64"/>
-  <reg name="hbadaddr" bitsize="64"/>
+  <reg name="hcounteren" bitsize="64"/>
+  <reg name="htval" bitsize="64"/>
   <reg name="hip" bitsize="64"/>
+  <reg name="htinst" bitsize="64"/>
+  <reg name="hgatp" bitsize="64"/>
   <reg name="mbase" bitsize="64"/>
   <reg name="mbound" bitsize="64"/>
   <reg name="mibase" bitsize="64"/>

--- a/gdb-xml/riscv-64bit-csr.xml
+++ b/gdb-xml/riscv-64bit-csr.xml
@@ -248,4 +248,10 @@
   <reg name="mucounteren" bitsize="64"/>
   <reg name="mscounteren" bitsize="64"/>
   <reg name="mhcounteren" bitsize="64"/>
+  <reg name="vstart" bitsize="64"/>
+  <reg name="vxsat" bitsize="64"/>
+  <reg name="vxrm" bitsize="64"/>
+  <reg name="vl" bitsize="64"/>
+  <reg name="vtype" bitsize="64"/>
+  <reg name="vlenb" bitsize="64"/>
 </feature>

--- a/gdb-xml/riscv-64bit-vector-128b.xml
+++ b/gdb-xml/riscv-64bit-vector-128b.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2018-2019 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!-- Register numbers are hard-coded in order to maintain backward
+     compatibility with older versions of tools that didn't use xml
+     register descriptions.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.riscv.vector">
+<vector id="bytes" type="uint8" count="16"/>
+<vector id="shorts" type="uint16" count="8"/>
+<vector id="words" type="uint32" count="4"/>
+<vector id="longs" type="uint64" count="2"/>
+<vector id="quads" type="uint128" count="1"/>
+  <union id="riscv_vector">
+    <field name="b" type="bytes"/>
+    <field name="s" type="shorts"/>
+    <field name="w" type="words"/>
+    <field name="l" type="longs"/>
+    <field name="q" type="quads"/>
+  </union>
+
+  <reg name="v0" bitsize="128" save-restore="no" type="riscv_vector" group="vector" regnum="69"/>
+  <reg name="v1" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v2" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v3" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v4" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v5" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v6" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v7" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v8" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v9" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v10" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v11" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v12" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v13" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v14" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v15" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v16" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v17" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v18" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v19" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v20" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v21" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v22" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v23" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v24" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v25" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v26" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v27" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v28" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v29" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v30" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v31" bitsize="128" save-restore="no" type="riscv_vector" group="vector"/>
+</feature>

--- a/gdb-xml/riscv-64bit-vector-256b.xml
+++ b/gdb-xml/riscv-64bit-vector-256b.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2018-2019 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!-- Register numbers are hard-coded in order to maintain backward
+     compatibility with older versions of tools that didn't use xml
+     register descriptions.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.riscv.vector">
+<vector id="bytes" type="uint8" count="32"/>
+<vector id="shorts" type="uint16" count="16"/>
+<vector id="words" type="uint32" count="8"/>
+<vector id="longs" type="uint64" count="4"/>
+<vector id="quads" type="uint128" count="2"/>
+  <union id="riscv_vector">
+    <field name="b" type="bytes"/>
+    <field name="s" type="shorts"/>
+    <field name="w" type="words"/>
+    <field name="l" type="longs"/>
+    <field name="q" type="quads"/>
+  </union>
+
+  <reg name="v0" bitsize="256" save-restore="no" type="riscv_vector" group="vector" regnum="69"/>
+  <reg name="v1" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v2" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v3" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v4" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v5" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v6" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v7" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v8" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v9" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v10" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v11" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v12" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v13" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v14" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v15" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v16" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v17" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v18" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v19" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v20" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v21" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v22" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v23" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v24" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v25" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v26" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v27" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v28" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v29" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v30" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v31" bitsize="256" save-restore="no" type="riscv_vector" group="vector"/>
+</feature>

--- a/gdb-xml/riscv-64bit-vector-512b.xml
+++ b/gdb-xml/riscv-64bit-vector-512b.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2018-2019 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!-- Register numbers are hard-coded in order to maintain backward
+     compatibility with older versions of tools that didn't use xml
+     register descriptions.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.riscv.vector">
+<vector id="bytes" type="uint8" count="64"/>
+<vector id="shorts" type="uint16" count="32"/>
+<vector id="words" type="uint32" count="16"/>
+<vector id="longs" type="uint64" count="8"/>
+<vector id="quads" type="uint128" count="4"/>
+  <union id="riscv_vector">
+    <field name="b" type="bytes"/>
+    <field name="s" type="shorts"/>
+    <field name="w" type="words"/>
+    <field name="l" type="longs"/>
+    <field name="q" type="quads"/>
+  </union>
+
+  <reg name="v0" bitsize="512" save-restore="no" type="riscv_vector" group="vector" regnum="69"/>
+  <reg name="v1" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v2" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v3" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v4" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v5" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v6" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v7" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v8" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v9" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v10" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v11" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v12" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v13" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v14" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v15" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v16" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v17" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v18" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v19" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v20" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v21" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v22" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v23" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v24" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v25" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v26" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v27" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v28" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v29" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v30" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+  <reg name="v31" bitsize="512" save-restore="no" type="riscv_vector" group="vector"/>
+</feature>

--- a/target/riscv/gdbstub.c
+++ b/target/riscv/gdbstub.c
@@ -418,13 +418,13 @@ void riscv_cpu_register_gdb_regs_for_features(CPUState *cs)
     }
 #if defined(TARGET_RISCV32)
     gdb_register_coprocessor(cs, riscv_gdb_get_csr, riscv_gdb_set_csr,
-                             240, "riscv-32bit-csr.xml", 0);
+                             241, "riscv-32bit-csr.xml", 0);
 
     gdb_register_coprocessor(cs, riscv_gdb_get_virtual, riscv_gdb_set_virtual,
                              1, "riscv-32bit-virtual.xml", 0);
 #elif defined(TARGET_RISCV64)
     gdb_register_coprocessor(cs, riscv_gdb_get_csr, riscv_gdb_set_csr,
-                             240, "riscv-64bit-csr.xml", 0);
+                             241, "riscv-64bit-csr.xml", 0);
 
     gdb_register_coprocessor(cs, riscv_gdb_get_virtual, riscv_gdb_set_virtual,
                              1, "riscv-64bit-virtual.xml", 0);

--- a/target/riscv/gdbstub.c
+++ b/target/riscv/gdbstub.c
@@ -268,6 +268,12 @@ static int csr_register_map[] = {
     CSR_MUCOUNTEREN,
     CSR_MSCOUNTEREN,
     CSR_MHCOUNTEREN,
+    CSR_VSTART,
+    CSR_VXSAT,
+    CSR_VXRM,
+    CSR_VL,
+    CSR_VTYPE,
+    CSR_VLENB,
 };
 
 int riscv_cpu_gdb_read_register(CPUState *cs, uint8_t *mem_buf, int n)
@@ -351,6 +357,32 @@ static int riscv_gdb_set_fpu(CPURISCVState *env, uint8_t *mem_buf, int n)
     return 0;
 }
 
+static int riscv_gdb_get_vector(CPURISCVState *env, uint8_t *mem_buf, int n)
+{
+    if (n < 32) {
+        int i;
+        int cnt = 0;
+        for (i = 0; i < env->vlenb; i += 8) {
+            cnt += gdb_get_reg64(mem_buf + i,
+                                 env->vreg[n * RV_VLEN_MAX / 64 + i / 8]);
+        }
+        return cnt;
+    }
+    return 0;
+}
+
+static int riscv_gdb_set_vector(CPURISCVState *env, uint8_t *mem_buf, int n)
+{
+    if (n < 32) {
+        int i;
+        for (i = 0; i < env->vlenb; i += 8) {
+            env->vreg[n * RV_VLEN_MAX / 64 + i / 8] = ldq_p(mem_buf + i);
+        }
+        return env->vlenb;
+    }
+    return 0;
+}
+
 static int riscv_gdb_get_csr(CPURISCVState *env, uint8_t *mem_buf, int n)
 {
     if (n < ARRAY_SIZE(csr_register_map)) {
@@ -416,15 +448,36 @@ void riscv_cpu_register_gdb_regs_for_features(CPUState *cs)
         gdb_register_coprocessor(cs, riscv_gdb_get_fpu, riscv_gdb_set_fpu,
                                  36, "riscv-32bit-fpu.xml", 0);
     }
+    if (env->misa & RVV) {
+        /* FIXME: It only supports vlen = 128, 256, 512 currently. */
+        const char *vector_xml_name = NULL;
+        switch (cpu->cfg.vlen) {
+            case 128:
+                vector_xml_name = "riscv-64bit-vector-128b.xml";
+                break;
+            case 256:
+                vector_xml_name = "riscv-64bit-vector-256b.xml";
+                break;
+            case 512:
+                vector_xml_name = "riscv-64bit-vector-512b.xml";
+                break;
+            default:
+                vector_xml_name = NULL;
+                break;
+        }
+        if (vector_xml_name)
+            gdb_register_coprocessor(cs, riscv_gdb_get_vector, riscv_gdb_set_vector,
+                                     32, vector_xml_name, 0);
+    }
 #if defined(TARGET_RISCV32)
     gdb_register_coprocessor(cs, riscv_gdb_get_csr, riscv_gdb_set_csr,
-                             241, "riscv-32bit-csr.xml", 0);
+                             247, "riscv-32bit-csr.xml", 0);
 
     gdb_register_coprocessor(cs, riscv_gdb_get_virtual, riscv_gdb_set_virtual,
                              1, "riscv-32bit-virtual.xml", 0);
 #elif defined(TARGET_RISCV64)
     gdb_register_coprocessor(cs, riscv_gdb_get_csr, riscv_gdb_set_csr,
-                             241, "riscv-64bit-csr.xml", 0);
+                             247, "riscv-64bit-csr.xml", 0);
 
     gdb_register_coprocessor(cs, riscv_gdb_get_virtual, riscv_gdb_set_virtual,
                              1, "riscv-64bit-virtual.xml", 0);


### PR DESCRIPTION
These two patches could enable qemu to view/modify vector registers, including vector CSR registers.